### PR TITLE
CRAN patch

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,5 @@
 (^|/)\.DS\_Store$
 ^\.git($|/)
 ^CRAN-SUBMISSION$
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ inst/doc
 inst/R.ignore
 cran-comments.md
 CRAN-SUBMISSION
+.positai

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dsROCrate
 Title: 'DataSHIELD' RO-Crate Governance Functions
-Version: 0.0.1
+Version: 0.0.1.9000
 Authors@R: c(
     person(given = "Roberto",
            family = "Villegas-Diaz",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dsROCrate
 Title: 'DataSHIELD' RO-Crate Governance Functions
-Version: 0.0.1.9000
+Version: 0.0.2
 Authors@R: c(
     person(given = "Roberto",
            family = "Villegas-Diaz",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# dsROCrate (development version)
+
 # dsROCrate 0.0.1
 
 * Initial CRAN submission.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # dsROCrate (development version)
 
+# dsROCrate 0.0.2
+
+* This patch addresses an issue with the vignettes. The `safe_output.opal()` S3
+generic now uses `overwrite = TRUE` to update the root (`./`) entity.
+
 # dsROCrate 0.0.1
 
 * Initial CRAN submission.

--- a/R/safe_output.R
+++ b/R/safe_output.R
@@ -395,7 +395,8 @@ safe_output.opal <- function(
           list(`@id` = log_entity$`@id`),
           list(`@id` = log_maps_entity$`@id`)
         )
-      )
+      ),
+      overwrite = TRUE
     )
 
   # attach input arguments as attributes

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,7 +20,6 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/dsROCrate)](https://CRAN.R-project.org/package=dsROCrate)
 [![R-CMD-check](https://github.com/FederatedMethods/dsROCrate/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/FederatedMethods/dsROCrate/actions/workflows/R-CMD-check.yaml)
-<!-- [![Codecov test coverage](https://codecov.io/gh/FederatedMethods/dsROCrate/graph/badge.svg)](https://app.codecov.io/gh/FederatedMethods/dsROCrate) -->
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![CRAN
 status](https://www.r-pkg.org/badges/version/dsROCrate)](https://CRAN.R-project.org/package=dsROCrate)
 [![R-CMD-check](https://github.com/FederatedMethods/dsROCrate/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/FederatedMethods/dsROCrate/actions/workflows/R-CMD-check.yaml)
-<!-- [![Codecov test coverage](https://codecov.io/gh/FederatedMethods/dsROCrate/graph/badge.svg)](https://app.codecov.io/gh/FederatedMethods/dsROCrate) -->
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -73,6 +73,10 @@ rocrate_txt <- function(rocrate) {
 
 ```{r setup}
 library(dsROCrate)
+
+# show all the lines in the RO-Crate
+oopt <- options(max_lines = Inf)
+on.exit(options(oopt), add = TRUE)
 ```
 
 This tutorial assumes that you have an internet connection and can access 
@@ -503,4 +507,6 @@ study_crate_v1 |>
 unlink(safe_people_crate_v1_rmd, TRUE, TRUE)
 unlink(safe_project_crate_v1_rmd, TRUE, TRUE)
 unlink(study_crate_v1_rmd, TRUE, TRUE)
+# reverse options
+options(oopt)
 ```


### PR DESCRIPTION
Addresses errors reported by CRAN with one of the vignettes. Closes #12 (see for details)